### PR TITLE
Update jquery.backstretch.js

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -501,7 +501,7 @@
                           oldImage.remove();
 
                           // Resume the slideshow
-                          if (!self.paused && this.images.length > 1) {
+                          if (!self.paused && self.images.length > 1) {
                             self.cycle();
                           }
 


### PR DESCRIPTION
Line 504 used a reference to this.images, but at that time, "this" referred to the <img> element and not to the backstretch object.  Using self.images instead seems to have solved the problem for me.
