### PR TITLE
Correct fadeFirst setting

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -512,15 +512,16 @@
                           });
                         };
 
-                        if (this.firstShow && !this.options.fadeFirstImage) {
+                        if (self.firstShow && !self.options.fadeFirst) {
                             // Avoid fade-in on first show
                             bringInNextImage();
+                            $(this).css({ "display": "inline-block" })
                         } else {
                             // Any other show, fade-in!
                             $(this).fadeIn(self.options.speed || self.options.fade, bringInNextImage);
                         }
                         
-                        this.firstShow = false;
+                        self.firstShow = false;
 
                         // Resize
                         self.resize();


### PR DESCRIPTION
This PR corrects some additional this vs. self confusion as well as corrects the behavior of the fadeFirst setting.  Please note that on line 518 I simply added a hack to be sure that the image is displayed.  Because the fadeIn() call is in the else-block, the image would never be shown when executing the if-block.  Furthermore, the self vs. this confusion on the new line 524 meant that the object thought it was _always_ the firstShow.  Regardless.  these changes have things working for me now.  Thanks for updating the original author's work.  The fadeFirst setting was exactly what I was looking for.
