### PR TITLE
Add backstretch.gravity()

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ $('.foo').backstretch("next");
 | `.backstretch("resume")` | Resume a paused slideshow. |
 | `.backstretch("destroy", preserveBackground)` | Destroy the Backstretch instance. Optionally, you can pass in a Boolean parameter, preserveBackground, to determine whether or not you'd like to keep the current image stretched as the background image. |
 | `.backstretch("resize")` | This method is called automatically when the container (window or block-level element) is resized, however you can always call this manually if needed. |
+| `.backstretch("gravity", g)` | Set the alignment (NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast) for the next image. |
 
 ## Public Variables
 

--- a/src/jquery.backstretch.js
+++ b/src/jquery.backstretch.js
@@ -587,6 +587,28 @@
         }
         this.$container.removeData('backstretch');
       }
+      
+    /**
+     * Sets the alignment (centeredX/Y, alignX/Y) for the next image.
+     * Invalid values are silently ignored.
+     * @param {String} gravity (NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast)
+     * @returns {Backstretch}
+     */
+    , gravity: function (gravity) {
+        var gravityOptions = {
+            NorthWest:  { alignX: 'left', alignY: 'top', centeredX: false, centeredY: false },
+            North:      { alignX: 'center', alignY: 'top', centeredX: true, centeredY: false },
+            NorthEast:  { alignX: 'right', alignY: 'top', centeredX: false, centeredY: false },
+            West:       { alignX: 'left', alignY: 'center', centeredX: false, centeredY: true },
+            Center:     { alignX: 'center', alignY: 'center', centeredX: true, centeredY: true },
+            East:       { alignX: 'right', alignY: 'center', centeredX: false, centeredY: true },
+            SouthWest:  { alignX: 'left', alignY: 'bottom', centeredX: false, centeredY: false },
+            South:      { alignX: 'center', alignY: 'bottom', centeredX: true, centeredY: false },
+            SouthEast:  { alignX: 'right', alignY: 'bottom', centeredX: false, centeredY: false }
+        };
+        this.options = $.extend({}, this.options, gravityOptions[gravity] || {});
+        return this;
+    }
   };
 
   /* SUPPORTS FIXED POSITION?


### PR DESCRIPTION
Added a new public method `gravity()` that sets the align/centered properties for standard compass directions NorthWest, North, NorthEast, West, Center, etc.  This is useful when one requires a different alignment for different images.  Use with trigger `backstretch.before`.

```
        var images = ["X", "Y", "Z"];
        var gravity = ["NorthWest", "Center", "SouthEast"];
        $(window).on("backstretch.before", function (e, instance, index) {
            //console.log("Setting gravity for #" + index + " (" + instance.images[index] + ") => " + gravity[index]);
            if (Math.abs(index) > gravity.length - 1) {
              return;
            }
            // Set the specific gravity for this image.
            instance.gravity(gravity[index]);
        });
```
